### PR TITLE
fix: Allow cross-origin requests.

### DIFF
--- a/openai_forward/app.py
+++ b/openai_forward/app.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI, Request, status
+from fastapi.middleware.cors import CORSMiddleware
 from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 
@@ -16,7 +17,13 @@ app = FastAPI(title="openai_forward", version="0.5")
 
 app.state.limiter = limiter
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
-
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 @app.get(
     "/healthz",


### PR DESCRIPTION
Fastapi默认不可跨域导致无法在不同域的ChatGPT Next中进行调用